### PR TITLE
Fix compilation for Linux v5.10

### DIFF
--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1473,15 +1473,19 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 	udpmsg.msg_control	= NULL;
 	udpmsg.msg_controllen = 0;
 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
-	oldfs = get_fs();
-	set_fs(KERNEL_DS);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        oldfs = get_fs();
+        set_fs(KERNEL_DS);
+    #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg);
 #else
 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg, msg_size);
 #endif
-	set_fs(oldfs);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        set_fs(oldfs);
+    #endif
 	if (error < 0) {
 		RTW_INFO("Error when sendimg msg, error:%d\n", error);
 		return _FAIL;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4770,8 +4770,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		return 0;
 	}
 
-	fs = get_fs();
-	set_fs(KERNEL_DS);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        fs = get_fs();
+        set_fs(KERNEL_DS);
+    #endif
 
 	source = rtw_zmalloc(2048);
 
@@ -4781,7 +4783,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		rtw_mfree(source, 2048);
 	}
 
-	set_fs(fs);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        set_fs(fs);
+    #endif
 	filp_close(fp, NULL);
 
 	RTW_INFO("-%s-\n", __func__);

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -4041,14 +4041,18 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 	msg.msg_controllen = 0;
 	msg.msg_flags = MSG_DONTWAIT;
 
-	oldfs = get_fs();
-	set_fs(KERNEL_DS);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        oldfs = get_fs();
+        set_fs(KERNEL_DS);
+    #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	err = sock_sendmsg(sock, &msg);
 #else
 	err = sock_sendmsg(sock, &msg, sizeof(req));
 #endif
-	set_fs(oldfs);
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+        set_fs(oldfs);
+    #endif
 
 	if (err < 0)
 		goto out_sock;
@@ -4073,14 +4077,18 @@ restart:
 		iov_iter_init(&msg.msg_iter, READ, &iov, 1, PAGE_SIZE);
 #endif
 
-		oldfs = get_fs();
-		set_fs(KERNEL_DS);
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            oldfs = get_fs();
+            set_fs(KERNEL_DS);
+        #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
 #else
 		err = sock_recvmsg(sock, &msg, PAGE_SIZE, MSG_DONTWAIT);
 #endif
-		set_fs(oldfs);
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            set_fs(oldfs);
+        #endif
 
 		if (err < 0)
 			goto out_sock_pg;
@@ -4151,14 +4159,18 @@ done:
 		msg.msg_controllen = 0;
 		msg.msg_flags = MSG_DONTWAIT;
 
-		oldfs = get_fs();
-		set_fs(KERNEL_DS);
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            oldfs = get_fs();
+            set_fs(KERNEL_DS);
+        #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		err = sock_sendmsg(sock, &msg);
 #else
 		err = sock_sendmsg(sock, &msg, sizeof(req));
 #endif
-		set_fs(oldfs);
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            set_fs(oldfs);
+        #endif
 
 		if (err > 0)
 			goto restart;

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2200,12 +2200,14 @@ static int isFileReadable(const char *path, u32 *sz)
 	if (IS_ERR(fp))
 		ret = PTR_ERR(fp);
 	else {
-		oldfs = get_fs();
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
-		set_fs(KERNEL_DS);
-		#else
-		set_fs(get_ds());
-		#endif
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            oldfs = get_fs();
+            #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+                set_fs(KERNEL_DS);
+            #else
+                set_fs(get_ds());
+            #endif
+        #endif
 
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
@@ -2218,7 +2220,9 @@ static int isFileReadable(const char *path, u32 *sz)
 			#endif
 		}
 
-		set_fs(oldfs);
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+            set_fs(oldfs);
+        #endif
 		filp_close(fp, NULL);
 	}
 	return ret;
@@ -2242,14 +2246,18 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 		if (0 == ret) {
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
-			oldfs = get_fs();
-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
-			set_fs(KERNEL_DS);
-			#else
-			set_fs(get_ds());
-			#endif
+            #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+                oldfs = get_fs();
+                #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+                    set_fs(KERNEL_DS);
+                #else
+                    set_fs(get_ds());
+                #endif
+            #endif
 			ret = readFile(fp, buf, sz);
-			set_fs(oldfs);
+            #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+                set_fs(oldfs);
+            #endif
 			closeFile(fp);
 
 			RTW_INFO("%s readFile, ret:%d\n", __FUNCTION__, ret);
@@ -2281,14 +2289,18 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 		if (0 == ret) {
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
-			oldfs = get_fs();
-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
-			set_fs(KERNEL_DS);
-			#else
-			set_fs(get_ds());
-			#endif
+            #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+                oldfs = get_fs();
+                #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+                    set_fs(KERNEL_DS);
+                #else
+                    set_fs(get_ds());
+                #endif
+            #endif
 			ret = writeFile(fp, buf, sz);
-			set_fs(oldfs);
+            #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+                set_fs(oldfs);
+            #endif
 			closeFile(fp);
 
 			RTW_INFO("%s writeFile, ret:%d\n", __FUNCTION__, ret);


### PR DESCRIPTION
This commit disables the use of the `get_fs()` and `set_fs()` calls
entirely when on Linux v5.10 and above. There was extensive media
coverage about these deprecations, e.g. on LWN https://lwn.net/Articles/832121/.

This patch is inspired by Carlos Garcés' fix for a related driver:
https://github.com/Mange/rtl8192eu-linux-driver/pull/201. Many thanks.